### PR TITLE
Update handler activation signal usage

### DIFF
--- a/mapclientplugins/pointcloudpartitionerstep/view/pointcloudpartitionerwidget.py
+++ b/mapclientplugins/pointcloudpartitionerstep/view/pointcloudpartitionerwidget.py
@@ -106,7 +106,7 @@ class PointCloudPartitionerWidget(QtWidgets.QWidget):
         self._ui.checkBoxSurfacesVisibility.stateChanged.connect(self._scene.set_surfaces_visibility)
         self._ui.checkBoxPointsVisibility.stateChanged.connect(self._scene.set_points_visibility)
         self._ui.pointSizeSpinBox.valueChanged.connect(self._scene.set_point_size)
-        self._ui.widgetZinc.handler_updated.connect(self._update_label_text)
+        self._ui.widgetZinc.handler_activated.connect(self._update_label_text)
         self._ui.widgetZinc.selection_updated.connect(self._selection_updated)
         self._ui.groupTableView.itemDelegateForColumn(1).button_clicked.connect(self._add_group_points_to_selection)
 
@@ -590,7 +590,7 @@ class PointCloudPartitionerWidget(QtWidgets.QWidget):
 
     def _update_label_text(self):
         handler_label_map = {SceneManipulation: "Mode: View", CustomSceneSelection: "Mode: Selection"}
-        handler_label = handler_label_map[type(self._ui.widgetZinc.get_active_handler())]
+        handler_label = handler_label_map[type(self._ui.widgetZinc.active_handler())]
         self._scene.update_label_text(handler_label)
 
     def register_done_execution(self, done_execution):

--- a/mapclientplugins/pointcloudpartitionerstep/view/zincpointcloudpartitionerwidget.py
+++ b/mapclientplugins/pointcloudpartitionerstep/view/zincpointcloudpartitionerwidget.py
@@ -10,7 +10,6 @@ from cmlibs.widgets.handlers.sceneselection import SceneSelection
 
 
 class ZincPointCloudPartitionerWidget(BaseSceneviewerWidget):
-    handler_updated = QtCore.Signal()
     selection_updated = QtCore.Signal()
 
     def __init__(self, parent=None):
@@ -20,17 +19,6 @@ class ZincPointCloudPartitionerWidget(BaseSceneviewerWidget):
 
     def set_model(self, model):
         self._model = model
-
-    def get_active_handler(self):
-        return self._active_handler
-
-    def register_handler(self, handler):
-        super().register_handler(handler)
-        self.handler_updated.emit()
-
-    def _activate_handler(self, handler):
-        super()._activate_handler(handler)
-        self.handler_updated.emit()
 
     def mouse_enter_event(self, event):
         super().mouse_enter_event(event)


### PR DESCRIPTION
This PR updates the `ZincPointCloudPartitionerWidget` to use the new handler activation/deactivation signals emitted by the `BaseSceneviewerWidget`.

Depends on [this PR](https://github.com/cmlibs-python/cmlibs.widgets/pull/67).